### PR TITLE
Change url project's website

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@ AC_INIT([mate-university],
         [1.7.0],
         [https://github.com/mate-desktop/mate-university/issues],
         [mate-university],
-        [http://www.mate-desktop.org])
+        [https://mate-desktop.org])
 
 AC_CONFIG_HEADERS(config.h)
 AC_PROG_CC

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends: debhelper (>= 8),
                libgtk2.0-dev,
                libmatepanelapplet-dev
 Standards-Version: 3.9.3
-Homepage: http://www.mate-desktop.org/
+Homepage: https://mate-desktop.org/
 
 Package: mate-university
 Architecture: any

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,7 +1,7 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: MATE University
 Upstream-Contact: Stefano Karapetsas <stefano@karapetsas.com>
-Source: http://www.mate-desktop.org/
+Source: https://mate-desktop.org/
 
 Files: *
 Copyright: 2013 Stefano Karapetsas


### PR DESCRIPTION
Now the official web site is https://mate-desktop.org/.