### PR TITLE
fix makefile and config issues

### DIFF
--- a/applet-c/Makefile.am
+++ b/applet-c/Makefile.am
@@ -28,7 +28,7 @@ servicedir       = $(datadir)/dbus-1/services
 service_in_files = org.mate.panel.applet.UniversityAppletFactory.service.in
 service_DATA     = $(service_in_files:.service.in=.service)
 
-org.mate.panel.applet.UniversityAppletFactory.service: $(service_in_files)
+org.mate.panel.applet.UniversityAppletFactory.service: $(service_in_files) Makefile
 	$(AM_V_GEN)sed \
 		-e "s|\@LOCATION\@|$(APPLET_LOCATION)|" \
 		$< > $@

--- a/applet-python/Makefile.am
+++ b/applet-python/Makefile.am
@@ -17,7 +17,7 @@ servicedir       = $(datadir)/dbus-1/services
 service_in_files = org.mate.panel.applet.UniversityPythonAppletFactory.service.in
 service_DATA     = $(service_in_files:.service.in=.service)
 
-org.mate.panel.applet.UniversityPythonAppletFactory.service: $(service_in_files)
+org.mate.panel.applet.UniversityPythonAppletFactory.service: $(service_in_files) Makefile
 	$(AM_V_GEN)sed \
 		-e "s|\@LOCATION\@|$(APPLET_LOCATION)|" \
 		$< > $@

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -1,4 +1,4 @@
 applet-c/applet.c
 [type: gettext/ini]applet-c/org.mate.university.Applet.mate-panel-applet.in.in
 [type: gettext/ini]applet-python/org.mate.university.PythonApplet.mate-panel-applet.in.in
-cairo-text/cairo-test.c
+cairo-test/cairo-test.c


### PR DESCRIPTION
I had to re-use this template to create an applet for myself, I had to fix small issues to be able to use it.

The `$(service_in_files)` makefile target missing `Makefile` after was apparently always there, but never an issue.  
But now it was one, because the `*.service` files pointed to the incorrect factories Exec paths (on my setup, linux mint 22/ubuntu 24.04).

And cairo-text was just a plain typing mistake ;)

